### PR TITLE
630:P1 InstancesController integration tests + 400 for invalid registration

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
@@ -31,6 +31,7 @@ import de.codecentric.boot.admin.server.eventstore.InstanceEventStore;
 import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
 import de.codecentric.boot.admin.server.utils.jackson.AdminServerModule;
+import de.codecentric.boot.admin.server.web.AdminControllerExceptionHandler;
 import de.codecentric.boot.admin.server.web.ApplicationsController;
 import de.codecentric.boot.admin.server.web.InstancesController;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
@@ -60,6 +61,12 @@ public class AdminServerWebConfiguration {
 	public ApplicationsController applicationsController(ApplicationRegistry applicationRegistry,
 			ApplicationEventPublisher applicationEventPublisher) {
 		return new ApplicationsController(applicationRegistry, applicationEventPublisher);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AdminControllerExceptionHandler adminControllerExceptionHandler() {
+		return new AdminControllerExceptionHandler();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/AdminControllerExceptionHandler.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/AdminControllerExceptionHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ServerWebInputException;
+import reactor.core.Exceptions;
+
+@RestControllerAdvice(annotations = AdminController.class)
+public class AdminControllerExceptionHandler {
+
+	@ExceptionHandler(ServerWebInputException.class)
+	public ResponseEntity<Void> handleWebInput(ServerWebInputException ex) {
+		Throwable cause = Exceptions.unwrap(ex);
+		if (cause instanceof IllegalArgumentException) {
+			return ResponseEntity.badRequest().build();
+		}
+		return ResponseEntity.badRequest().build();
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Void> handleIllegalArgument(IllegalArgumentException ex) {
+		return ResponseEntity.badRequest().build();
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/InstancesControllerIntegrationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/InstancesControllerIntegrationTest.java
@@ -84,6 +84,105 @@ class InstancesControllerIntegrationTest {
 	}
 
 	@Test
+	void should_reject_invalid_json() {
+		this.client.post()
+			.uri("/instances")
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue("{")
+			.exchange()
+			.expectStatus()
+			.isBadRequest();
+	}
+
+	@Test
+	void should_reject_missing_name() {
+		String body = "{ \"healthUrl\": \"http://localhost:" + localPort + "/application/health\" }";
+
+		this.client.post()
+			.uri("/instances")
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(body)
+			.exchange()
+			.expectStatus()
+			.isBadRequest();
+	}
+
+	@Test
+	void should_reject_missing_health_url() {
+		String body = "{ \"name\": \"noname\" }";
+
+		this.client.post()
+			.uri("/instances")
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(body)
+			.exchange()
+			.expectStatus()
+			.isBadRequest();
+	}
+
+	@Test
+	void should_create_distinct_ids_for_different_health_urls() {
+		String id1 = register();
+
+		String other = "{ \"name\": \"other\", \"healthUrl\": \"http://localhost:" + localPort + "/other/health\" }";
+		String id2 = registerWithBody(other);
+
+		assertThat(id2).isNotEqualTo(id1);
+
+		assertInstanceById(id1);
+		assertInstanceById(id2);
+	}
+
+	@Test
+	void should_remove_instance_after_delete() {
+		String id = register();
+
+		this.client.delete().uri(getLocation(id)).exchange().expectStatus().isNoContent();
+
+		this.client.get().uri(getLocation(id)).exchange().expectStatus().isNotFound();
+
+		this.client.get()
+			.uri("/instances")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
+			.expectBody(String.class)
+			.consumeWith((response) -> {
+				DocumentContext json = JsonPath.parse(response.getResponseBody());
+				List<String> ids = json.read("$[?(@.id == '" + id + "')].id");
+				assertThat(ids).isEmpty();
+			});
+
+	}
+
+	@Test
+	void should_not_create_duplicate_instance_on_reregister() {
+		String id = register();
+
+		registerSecondTime(id);
+
+		this.client.get()
+			.uri("/instances")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectHeader()
+			.contentType(MediaType.APPLICATION_JSON)
+			.expectBody(String.class)
+			.consumeWith((response) -> {
+				DocumentContext json = JsonPath.parse(response.getResponseBody());
+				List<String> ids = json.read("$[?(@.id == '" + id + "')].id");
+				assertThat(ids).hasSize(1);
+			});
+
+	}
+
+	@Test
 	void should_return_empty_list() {
 		this.client.get()
 			.uri("/instances?name=unknown")
@@ -245,6 +344,23 @@ class InstancesControllerIntegrationTest {
 																.expectHeader().valueMatches("location", "http://localhost:" + localPort + "/instances/[0-9a-f]+")
 																.expectBody(responseType)
 																.returnResult();
+		//@formatter:on
+		assertThat(result.getResponseBody()).containsKeys("id");
+		return result.getResponseBody().get("id").toString();
+	}
+
+	private String registerWithBody(String body) {
+		//@formatter:off
+		EntityExchangeResult<Map<String, Object>> result = client.post()
+			.uri("/instances")
+			.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(body)
+			.exchange()
+			.expectStatus().isCreated()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectHeader().valueMatches("location", "http://localhost:" + localPort + "/instances/[0-9a-f]+")
+			.expectBody(responseType)
+			.returnResult();
 		//@formatter:on
 		assertThat(result.getResponseBody()).containsKeys("id");
 		return result.getResponseBody().get("id").toString();


### PR DESCRIPTION
## Summary
Adds regression protection for instance registration and basic lifecycle endpoints.

## Added tests (InstancesControllerIntegrationTest)
1) reject invalid JSON (400)
2) reject missing name (400)
3) reject missing healthUrl (400)
4) distinct ids for different healthUrl
5) delete removes instance (404 + not returned by /instances)
6) re-register does not create duplicate instance

## Targeted regression improvement (production)
Invalid registration payloads previously surfaced as 500 due to IllegalArgumentException during binding/validation.
Added an AdminController-scoped exception handler so invalid registration inputs return 400 Bad Request.

## How to run
mvnw -pl spring-boot-admin-server -Dtest=InstancesControllerIntegrationTest test
