### PR TITLE
630:P2 Extract instance types and state constants from services/instance.ts

### DIFF
--- a/docs/time_log.csv
+++ b/docs/time_log.csv
@@ -29,3 +29,5 @@ Add-Content docs/time_log.csv '2026-04-06,15,Convert TODO tech-debt markers into
 2026-04-06,17,Stop swallowing instance registration failures,Akshith,verify,15,Reviewed diff to confirm only listener test and time log changed and existing continuation behavior test remains relevant,
 2026-04-06,17,Stop swallowing instance registration failures,Akshith,pr_overhead,15,Opened PR and added summary verification and evidence,https://github.com/amacharla15/spring-boot-admin/pull/26
 2026-04-06,17,Stop swallowing instance registration failures,Akshith,review,15,Performed solo self-review on PR 26,https://github.com/amacharla15/spring-boot-admin/pull/26
+2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,implement,15,Extracted shared types and status constants from instance.ts into instance.types.ts while preserving exports,
+2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,verify,15,Checked diff to confirm extraction stayed limited to instance.ts new instance.types.ts and time log,

--- a/docs/time_log.csv
+++ b/docs/time_log.csv
@@ -31,3 +31,5 @@ Add-Content docs/time_log.csv '2026-04-06,15,Convert TODO tech-debt markers into
 2026-04-06,17,Stop swallowing instance registration failures,Akshith,review,15,Performed solo self-review on PR 26,https://github.com/amacharla15/spring-boot-admin/pull/26
 2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,implement,15,Extracted shared types and status constants from instance.ts into instance.types.ts while preserving exports,
 2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,verify,15,Checked diff to confirm extraction stayed limited to instance.ts new instance.types.ts and time log,
+2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,pr_overhead,15,Opened PR and added summary verification and evidence,https://github.com/amacharla15/spring-boot-admin/pull/27
+2026-04-06,13,Split frontend services/instance.ts into cohesive service modules,Akshith,review,15,Performed solo self-review on PR 27,https://github.com/amacharla15/spring-boot-admin/pull/27

--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
@@ -28,6 +28,7 @@ import uri from '../utils/uri';
 import { useSbaConfig } from '@/sba-config';
 import { actuatorMimeTypes } from '@/services/spring-mime-types';
 import { transformToJSON } from '@/utils/transformToJSON';
+import type { Registration, StatusInfo } from './instance.types';
 
 const isInstanceActuatorRequest = (url: string) =>
   url.match(/^instances[/][^/]+[/]actuator([/].*)?$/);
@@ -473,29 +474,8 @@ class Instance {
   }
 }
 
+
 export default Instance;
 
-export type Registration = {
-  name: string;
-  managementUrl?: string;
-  healthUrl: string;
-  serviceUrl?: string;
-  source: string;
-  metadata?: { [key: string]: string }[];
-};
-
-type StatusInfo = {
-  status:
-    | 'UNKNOWN'
-    | 'OUT_OF_SERVICE'
-    | 'UP'
-    | 'DOWN'
-    | 'OFFLINE'
-    | 'RESTRICTED'
-    | string;
-  details: { [key: string]: string };
-};
-
-export const DOWN_STATES = ['OUT_OF_SERVICE', 'DOWN', 'OFFLINE', 'RESTRICTED'];
-export const UP_STATES = ['UP'];
-export const UNKNOWN_STATES = ['UNKNOWN'];
+export type { Registration } from './instance.types';
+export { DOWN_STATES, UP_STATES, UNKNOWN_STATES } from './instance.types';

--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.types.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.types.ts
@@ -1,0 +1,24 @@
+export type Registration = {
+  name: string;
+  managementUrl?: string;
+  healthUrl: string;
+  serviceUrl?: string;
+  source: string;
+  metadata?: { [key: string]: string }[];
+};
+
+export type StatusInfo = {
+  status:
+    | 'UNKNOWN'
+    | 'OUT_OF_SERVICE'
+    | 'UP'
+    | 'DOWN'
+    | 'OFFLINE'
+    | 'RESTRICTED'
+    | string;
+  details: { [key: string]: string };
+};
+
+export const DOWN_STATES = ['OUT_OF_SERVICE', 'DOWN', 'OFFLINE', 'RESTRICTED'];
+export const UP_STATES = ['UP'];
+export const UNKNOWN_STATES = ['UNKNOWN'];


### PR DESCRIPTION
Closes #13

Summary
- Extracted Registration, StatusInfo, and instance state constants from services/instance.ts into a new instance.types.ts module
- Kept the public API stable by re-exporting Registration and the state constants from services/instance.ts
- Kept the change scoped to a small, reviewable extraction

Verification
- Reviewed the diff and confirmed the extraction is limited to instance.ts, the new instance.types.ts file, and the time log
- Confirmed services/instance.ts still re-exports Registration and the state constants so existing callers can continue using the same import surface

Evidence
- Reduces the size and responsibility of services/instance.ts by moving cohesive type/constant definitions into a dedicated module
- Affected files:
  - spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
  - spring-boot-admin-server-ui/src/main/frontend/services/instance.types.ts

Self-review (solo project)
- Reviewed changed files for scope control and unintended churn
- Checked acceptance criteria against the issue
- Verified the file-level change listed above