### PR TITLE
630:P3 #33 refactor HttpHeaderFilter using Strategy

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/DefaultHeaderFilterStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/DefaultHeaderFilterStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DefaultHeaderFilterStrategy implements HeaderFilterStrategy {
+
+	private static final String[] HOP_BY_HOP_HEADERS = new String[] { "Host", "Connection", "Keep-Alive",
+			"Proxy-Authenticate", "Proxy-Authorization", "TE", "Trailer", "Transfer-Encoding", "Upgrade",
+			"X-Application-Context" };
+
+	private final Set<String> ignoredHeaders;
+
+	public DefaultHeaderFilterStrategy(Set<String> ignoredHeaders) {
+		this.ignoredHeaders = Stream.concat(ignoredHeaders.stream(), Arrays.stream(HOP_BY_HOP_HEADERS))
+			.map(String::toLowerCase)
+			.collect(Collectors.toSet());
+	}
+
+	@Override
+	public boolean includeHeader(String header) {
+		return !this.ignoredHeaders.contains(header.toLowerCase());
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/HeaderFilterStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/HeaderFilterStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web;
+
+public interface HeaderFilterStrategy {
+
+	boolean includeHeader(String header);
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/HttpHeaderFilter.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/HttpHeaderFilter.java
@@ -16,11 +16,8 @@
 
 package de.codecentric.boot.admin.server.web;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.http.HttpHeaders;
 
@@ -34,16 +31,14 @@ import static java.util.stream.Collectors.toMap;
  */
 public class HttpHeaderFilter {
 
-	private static final String[] HOP_BY_HOP_HEADERS = new String[] { "Host", "Connection", "Keep-Alive",
-			"Proxy-Authenticate", "Proxy-Authorization", "TE", "Trailer", "Transfer-Encoding", "Upgrade",
-			"X-Application-Context" };
-
-	private final Set<String> ignoredHeaders;
+	private final HeaderFilterStrategy headerFilterStrategy;
 
 	public HttpHeaderFilter(Set<String> ignoredHeaders) {
-		this.ignoredHeaders = Stream.concat(ignoredHeaders.stream(), Arrays.stream(HOP_BY_HOP_HEADERS))
-			.map(String::toLowerCase)
-			.collect(Collectors.toSet());
+		this(new DefaultHeaderFilterStrategy(ignoredHeaders));
+	}
+
+	public HttpHeaderFilter(HeaderFilterStrategy headerFilterStrategy) {
+		this.headerFilterStrategy = headerFilterStrategy;
 	}
 
 	public HttpHeaders filterHeaders(HttpHeaders headers) {
@@ -56,7 +51,7 @@ public class HttpHeaderFilter {
 	}
 
 	private boolean includeHeader(String header) {
-		return !this.ignoredHeaders.contains(header.toLowerCase());
+		return this.headerFilterStrategy.includeHeader(header);
 	}
 
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/HttpHeaderFilterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/HttpHeaderFilterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpHeaderFilterTest {
+
+	@Test
+	void should_filter_hop_by_hop_headers_and_configured_ignored_headers() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.HOST, "example.com");
+		headers.add(HttpHeaders.CONNECTION, "keep-alive");
+		headers.add("X-Application-Context", "test");
+		headers.add("X-Ignored", "secret");
+		headers.add("X-Kept", "value");
+
+		HttpHeaderFilter filter = new HttpHeaderFilter(Collections.singleton("X-Ignored"));
+		HttpHeaders filtered = filter.filterHeaders(headers);
+
+		assertThat(filtered).doesNotContainKey(HttpHeaders.HOST);
+		assertThat(filtered).doesNotContainKey(HttpHeaders.CONNECTION);
+		assertThat(filtered).doesNotContainKey("X-Application-Context");
+		assertThat(filtered).doesNotContainKey("X-Ignored");
+		assertThat(filtered).containsKey("X-Kept");
+	}
+
+	@Test
+	void should_delegate_header_decision_to_strategy() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("X-Allow", "1");
+		headers.add("X-Deny", "2");
+
+		HeaderFilterStrategy strategy = (header) -> !"X-Deny".equalsIgnoreCase(header);
+		HttpHeaderFilter filter = new HttpHeaderFilter(strategy);
+		HttpHeaders filtered = filter.filterHeaders(headers);
+
+		assertThat(filtered).containsKey("X-Allow");
+		assertThat(filtered).doesNotContainKey("X-Deny");
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR closes #33 by refactoring HttpHeaderFilter to use the Strategy pattern for header inclusion/exclusion decisions.

Previously, HttpHeaderFilter directly owned both the filtering operation and the filtering policy. It stored the default hop-by-hop headers, merged them with configured ignored headers, and decided whether each header should be included. That made the class less flexible because changing the filtering policy required editing HttpHeaderFilter itself.

After this refactor, HttpHeaderFilter keeps the filtering workflow, while HeaderFilterStrategy owns the include/exclude decision. DefaultHeaderFilterStrategy preserves the existing default behavior by filtering hop-by-hop headers and configured ignored headers.

## Design Pattern

Pattern used: Strategy

- HeaderFilterStrategy defines the policy interface.
- DefaultHeaderFilterStrategy provides the default policy.
- HttpHeaderFilter delegates header decisions to the strategy.

## Behavior Change

No user-visible behavior was intentionally changed.

## Verification

Ran:

.\mvnw.cmd -pl spring-boot-admin-server -Dtest=HttpHeaderFilterTest test

Result:

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

Also ran:

.\mvnw.cmd -pl spring-boot-admin-server -DskipTests compile

Result:

BUILD SUCCESS

Closes #33