### PR TITLE
630:P3 #31 refactor update triggers using Strategy

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractInstanceUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractInstanceUpdateTrigger.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.services;
+
+import java.time.Duration;
+
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
+import de.codecentric.boot.admin.server.domain.values.InstanceId;
+
+public abstract class AbstractInstanceUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
+
+	private static final Logger log = LoggerFactory.getLogger(AbstractInstanceUpdateTrigger.class);
+
+	private final InstanceUpdateTriggerStrategy triggerStrategy;
+
+	private final IntervalCheck intervalCheck;
+
+	protected AbstractInstanceUpdateTrigger(Publisher<InstanceEvent> publisher,
+			InstanceUpdateTriggerStrategy triggerStrategy, Duration updateInterval, Duration lifetime,
+			Duration maxBackoff) {
+		super(publisher, InstanceEvent.class);
+		this.triggerStrategy = triggerStrategy;
+		this.intervalCheck = new IntervalCheck(triggerStrategy.getName(), this::updateInstance, updateInterval,
+				lifetime, maxBackoff);
+	}
+
+	@Override
+	protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
+		return publisher.filter(this.triggerStrategy::supports).flatMap((event) -> updateInstance(event.getInstance()));
+	}
+
+	protected Mono<Void> updateInstance(InstanceId instanceId) {
+		return this.triggerStrategy.update(instanceId, this.intervalCheck.getInterval()).onErrorResume((e) -> {
+			log.warn("Unexpected error while updating {} for {}", this.triggerStrategy.getName(), instanceId, e);
+			return Mono.empty();
+		}).doFinally((s) -> this.intervalCheck.markAsChecked(instanceId));
+	}
+
+	@Override
+	public void start() {
+		super.start();
+		this.intervalCheck.start();
+	}
+
+	@Override
+	public void stop() {
+		super.stop();
+		this.intervalCheck.stop();
+	}
+
+	public void setInterval(Duration updateInterval) {
+		this.intervalCheck.setInterval(updateInterval);
+	}
+
+	public void setLifetime(Duration lifetime) {
+		this.intervalCheck.setMinRetention(lifetime);
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTriggerStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTriggerStrategy.java
@@ -18,26 +18,36 @@ package de.codecentric.boot.admin.server.services;
 
 import java.time.Duration;
 
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import de.codecentric.boot.admin.server.domain.events.InstanceEndpointsDetectedEvent;
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceRegistrationUpdatedEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceStatusChangedEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 
-public class InfoUpdateTrigger extends AbstractInstanceUpdateTrigger {
+public class InfoUpdateTriggerStrategy implements InstanceUpdateTriggerStrategy {
 
-	public InfoUpdateTrigger(InfoUpdater infoUpdater, Publisher<InstanceEvent> publisher, Duration updateInterval,
-			Duration infoLifetime, Duration maxBackoff) {
-		this(new InfoUpdateTriggerStrategy(infoUpdater), publisher, updateInterval, infoLifetime, maxBackoff);
+	private final InfoUpdater infoUpdater;
+
+	public InfoUpdateTriggerStrategy(InfoUpdater infoUpdater) {
+		this.infoUpdater = infoUpdater;
 	}
 
-	InfoUpdateTrigger(InstanceUpdateTriggerStrategy triggerStrategy, Publisher<InstanceEvent> publisher,
-			Duration updateInterval, Duration infoLifetime, Duration maxBackoff) {
-		super(publisher, triggerStrategy, updateInterval, infoLifetime, maxBackoff);
+	@Override
+	public String getName() {
+		return "info";
 	}
 
-	protected Mono<Void> updateInfo(InstanceId instanceId) {
-		return updateInstance(instanceId);
+	@Override
+	public boolean supports(InstanceEvent event) {
+		return event instanceof InstanceEndpointsDetectedEvent || event instanceof InstanceStatusChangedEvent
+				|| event instanceof InstanceRegistrationUpdatedEvent;
+	}
+
+	@Override
+	public Mono<Void> update(InstanceId instanceId, Duration timeout) {
+		return this.infoUpdater.updateInfo(instanceId);
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceUpdateTriggerStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceUpdateTriggerStrategy.java
@@ -18,26 +18,17 @@ package de.codecentric.boot.admin.server.services;
 
 import java.time.Duration;
 
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 
-public class InfoUpdateTrigger extends AbstractInstanceUpdateTrigger {
+public interface InstanceUpdateTriggerStrategy {
 
-	public InfoUpdateTrigger(InfoUpdater infoUpdater, Publisher<InstanceEvent> publisher, Duration updateInterval,
-			Duration infoLifetime, Duration maxBackoff) {
-		this(new InfoUpdateTriggerStrategy(infoUpdater), publisher, updateInterval, infoLifetime, maxBackoff);
-	}
+	String getName();
 
-	InfoUpdateTrigger(InstanceUpdateTriggerStrategy triggerStrategy, Publisher<InstanceEvent> publisher,
-			Duration updateInterval, Duration infoLifetime, Duration maxBackoff) {
-		super(publisher, triggerStrategy, updateInterval, infoLifetime, maxBackoff);
-	}
+	boolean supports(InstanceEvent event);
 
-	protected Mono<Void> updateInfo(InstanceId instanceId) {
-		return updateInstance(instanceId);
-	}
+	Mono<Void> update(InstanceId instanceId, Duration timeout);
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
@@ -19,68 +19,25 @@ package de.codecentric.boot.admin.server.services;
 import java.time.Duration;
 
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
-import de.codecentric.boot.admin.server.domain.events.InstanceRegisteredEvent;
-import de.codecentric.boot.admin.server.domain.events.InstanceRegistrationUpdatedEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 
-public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
-
-	private static final Logger log = LoggerFactory.getLogger(StatusUpdateTrigger.class);
-
-	private final StatusUpdater statusUpdater;
-
-	private final IntervalCheck intervalCheck;
+public class StatusUpdateTrigger extends AbstractInstanceUpdateTrigger {
 
 	public StatusUpdateTrigger(StatusUpdater statusUpdater, Publisher<InstanceEvent> publisher, Duration updateInterval,
 			Duration statusLifetime, Duration maxBackoff) {
-		super(publisher, InstanceEvent.class);
-		this.statusUpdater = statusUpdater;
-		this.intervalCheck = new IntervalCheck("status", this::updateStatus, updateInterval, statusLifetime,
-				maxBackoff);
+		this(new StatusUpdateTriggerStrategy(statusUpdater), publisher, updateInterval, statusLifetime, maxBackoff);
 	}
 
-	@Override
-	protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
-		return publisher
-			.filter((event) -> event instanceof InstanceRegisteredEvent
-					|| event instanceof InstanceRegistrationUpdatedEvent)
-			.flatMap((event) -> updateStatus(event.getInstance()));
+	StatusUpdateTrigger(InstanceUpdateTriggerStrategy triggerStrategy, Publisher<InstanceEvent> publisher,
+			Duration updateInterval, Duration statusLifetime, Duration maxBackoff) {
+		super(publisher, triggerStrategy, updateInterval, statusLifetime, maxBackoff);
 	}
 
 	protected Mono<Void> updateStatus(InstanceId instanceId) {
-		return this.statusUpdater.timeout(this.intervalCheck.getInterval())
-			.updateStatus(instanceId)
-			.onErrorResume((e) -> {
-				log.warn("Unexpected error while updating status for {}", instanceId, e);
-				return Mono.empty();
-			})
-			.doFinally((s) -> this.intervalCheck.markAsChecked(instanceId));
-	}
-
-	@Override
-	public void start() {
-		super.start();
-		this.intervalCheck.start();
-	}
-
-	@Override
-	public void stop() {
-		super.stop();
-		this.intervalCheck.stop();
-	}
-
-	public void setInterval(Duration updateInterval) {
-		this.intervalCheck.setInterval(updateInterval);
-	}
-
-	public void setLifetime(Duration statusLifetime) {
-		this.intervalCheck.setMinRetention(statusLifetime);
+		return updateInstance(instanceId);
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTriggerStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTriggerStrategy.java
@@ -18,26 +18,34 @@ package de.codecentric.boot.admin.server.services;
 
 import java.time.Duration;
 
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceRegisteredEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceRegistrationUpdatedEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 
-public class InfoUpdateTrigger extends AbstractInstanceUpdateTrigger {
+public class StatusUpdateTriggerStrategy implements InstanceUpdateTriggerStrategy {
 
-	public InfoUpdateTrigger(InfoUpdater infoUpdater, Publisher<InstanceEvent> publisher, Duration updateInterval,
-			Duration infoLifetime, Duration maxBackoff) {
-		this(new InfoUpdateTriggerStrategy(infoUpdater), publisher, updateInterval, infoLifetime, maxBackoff);
+	private final StatusUpdater statusUpdater;
+
+	public StatusUpdateTriggerStrategy(StatusUpdater statusUpdater) {
+		this.statusUpdater = statusUpdater;
 	}
 
-	InfoUpdateTrigger(InstanceUpdateTriggerStrategy triggerStrategy, Publisher<InstanceEvent> publisher,
-			Duration updateInterval, Duration infoLifetime, Duration maxBackoff) {
-		super(publisher, triggerStrategy, updateInterval, infoLifetime, maxBackoff);
+	@Override
+	public String getName() {
+		return "status";
 	}
 
-	protected Mono<Void> updateInfo(InstanceId instanceId) {
-		return updateInstance(instanceId);
+	@Override
+	public boolean supports(InstanceEvent event) {
+		return event instanceof InstanceRegisteredEvent || event instanceof InstanceRegistrationUpdatedEvent;
+	}
+
+	@Override
+	public Mono<Void> update(InstanceId instanceId, Duration timeout) {
+		return this.statusUpdater.timeout(timeout).updateStatus(instanceId);
 	}
 
 }


### PR DESCRIPTION
## Summary

This PR closes #31 by refactoring StatusUpdateTrigger and InfoUpdateTrigger toward the Strategy pattern.

Previously, both trigger classes directly owned the same broad trigger workflow: filtering instance events, invoking the correct updater, handling update errors, managing interval checks, and wiring lifecycle behavior. The main variation between the two classes was policy-based: which events should trigger an update and which updater should run.

After this refactor, AbstractInstanceUpdateTrigger owns the shared trigger workflow, while InstanceUpdateTriggerStrategy defines the variable policy. StatusUpdateTriggerStrategy handles status-trigger policy, and InfoUpdateTriggerStrategy handles info-trigger policy.

## Design Pattern

Pattern used: Strategy

- InstanceUpdateTriggerStrategy defines the trigger policy interface.
- StatusUpdateTriggerStrategy selects status-related events and calls StatusUpdater.
- InfoUpdateTriggerStrategy selects info-related events and calls InfoUpdater.
- AbstractInstanceUpdateTrigger keeps the shared trigger skeleton and lifecycle behavior.
- StatusUpdateTrigger and InfoUpdateTrigger become thin wiring classes.

## Behavior Change

No user-visible behavior was intentionally changed.

## Verification

Ran:

.\mvnw.cmd -pl spring-boot-admin-server "-Dtest=StatusUpdateTriggerTest,InfoUpdateTriggerTest" test

Result:

Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

Also ran:

.\mvnw.cmd -pl spring-boot-admin-server -DskipTests compile

Result:

BUILD SUCCESS

Closes #31