### PR TITLE
630:P3 #30 Refactor StatusUpdater and InfoUpdater using Template Method

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractInstanceEndpointUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractInstanceEndpointUpdater.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.services;
+
+import java.util.logging.Level;
+
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+import de.codecentric.boot.admin.server.domain.entities.Instance;
+import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
+import de.codecentric.boot.admin.server.domain.values.InstanceId;
+import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
+
+public abstract class AbstractInstanceEndpointUpdater<T> {
+
+	private final InstanceRepository repository;
+
+	private final InstanceWebClient instanceWebClient;
+
+	private final ApiMediaTypeHandler apiMediaTypeHandler;
+
+	protected AbstractInstanceEndpointUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
+			ApiMediaTypeHandler apiMediaTypeHandler) {
+		this.repository = repository;
+		this.instanceWebClient = instanceWebClient;
+		this.apiMediaTypeHandler = apiMediaTypeHandler;
+	}
+
+	protected Mono<Void> update(InstanceId id) {
+		return this.repository.computeIfPresent(id, (key, instance) -> doUpdate(instance)).then();
+	}
+
+	protected Mono<Instance> doUpdate(Instance instance) {
+		if (!shouldUpdate(instance)) {
+			return Mono.empty();
+		}
+
+		logUpdate(instance);
+
+		Mono<T> response = this.instanceWebClient.instance(instance)
+			.get()
+			.uri(getEndpoint())
+			.exchangeToMono((clientResponse) -> convertResponse(instance, clientResponse))
+			.log(getLoggerName(), Level.FINEST);
+
+		return applyRequestOptions(response).doOnError((ex) -> logError(instance, ex))
+			.onErrorResume((ex) -> handleError(instance, ex))
+			.map((value) -> applyUpdate(instance, value));
+	}
+
+	protected ApiMediaTypeHandler getApiMediaTypeHandler() {
+		return this.apiMediaTypeHandler;
+	}
+
+	protected Mono<T> applyRequestOptions(Mono<T> response) {
+		return response;
+	}
+
+	protected void logError(Instance instance, Throwable ex) {
+	}
+
+	protected abstract boolean shouldUpdate(Instance instance);
+
+	protected abstract void logUpdate(Instance instance);
+
+	protected abstract String getEndpoint();
+
+	protected abstract Mono<T> convertResponse(Instance instance, ClientResponse response);
+
+	protected abstract Mono<T> handleError(Instance instance, Throwable ex);
+
+	protected abstract Instance applyUpdate(Instance instance, T value);
+
+	protected abstract String getLoggerName();
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
@@ -17,7 +17,6 @@
 package de.codecentric.boot.admin.server.services;
 
 import java.util.Map;
-import java.util.logging.Level;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,53 +38,63 @@ import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
  *
  * @author Johannes Edmeier
  */
-public class InfoUpdater {
+public class InfoUpdater extends AbstractInstanceEndpointUpdater<Info> {
 
 	private static final Logger log = LoggerFactory.getLogger(InfoUpdater.class);
 
 	private static final ParameterizedTypeReference<Map<String, Object>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {
 	};
 
-	private final InstanceRepository repository;
-
-	private final InstanceWebClient instanceWebClient;
-
-	private final ApiMediaTypeHandler apiMediaTypeHandler;
-
 	public InfoUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
 			ApiMediaTypeHandler apiMediaTypeHandler) {
-		this.repository = repository;
-		this.instanceWebClient = instanceWebClient;
-		this.apiMediaTypeHandler = apiMediaTypeHandler;
+		super(repository, instanceWebClient, apiMediaTypeHandler);
 	}
 
 	public Mono<Void> updateInfo(InstanceId id) {
-		return this.repository.computeIfPresent(id, (key, instance) -> this.doUpdateInfo(instance)).then();
+		return update(id);
 	}
 
-	protected Mono<Instance> doUpdateInfo(Instance instance) {
-		if (instance.getStatusInfo().isOffline() || instance.getStatusInfo().isUnknown()) {
-			return Mono.empty();
-		}
-		if (!instance.getEndpoints().isPresent(Endpoint.INFO)) {
-			return Mono.empty();
-		}
+	@Override
+	protected boolean shouldUpdate(Instance instance) {
+		return !instance.getStatusInfo().isOffline() && !instance.getStatusInfo().isUnknown()
+				&& instance.getEndpoints().isPresent(Endpoint.INFO);
+	}
 
+	@Override
+	protected void logUpdate(Instance instance) {
 		log.debug("Update info for {}", instance);
-		return this.instanceWebClient.instance(instance)
-			.get()
-			.uri(Endpoint.INFO)
-			.exchangeToMono((response) -> convertInfo(instance, response))
-			.log(log.getName(), Level.FINEST)
-			.onErrorResume((ex) -> Mono.just(convertInfo(instance, ex)))
-			.map(instance::withInfo);
+	}
+
+	@Override
+	protected String getEndpoint() {
+		return Endpoint.INFO;
+	}
+
+	@Override
+	protected Mono<Info> convertResponse(Instance instance, ClientResponse response) {
+		return convertInfo(instance, response);
+	}
+
+	@Override
+	protected Mono<Info> handleError(Instance instance, Throwable ex) {
+		return Mono.just(convertInfo(instance, ex));
+	}
+
+	@Override
+	protected Instance applyUpdate(Instance instance, Info info) {
+		return instance.withInfo(info);
+	}
+
+	@Override
+	protected String getLoggerName() {
+		return log.getName();
 	}
 
 	protected Mono<Info> convertInfo(Instance instance, ClientResponse response) {
 		if (response.statusCode().is2xxSuccessful() && response.headers()
 			.contentType()
 			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON)
-					|| this.apiMediaTypeHandler.isApiMediaType(mt))
+					|| getApiMediaTypeHandler().isApiMediaType(mt))
 			.isPresent()) {
 			return response.bodyToMono(RESPONSE_TYPE).map(Info::from).defaultIfEmpty(Info.empty());
 		}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
@@ -21,9 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Level;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
@@ -48,19 +46,17 @@ import static java.util.Collections.emptyMap;
  * @author Johannes Edmeier
  */
 @Slf4j
-@RequiredArgsConstructor
-public class StatusUpdater {
+public class StatusUpdater extends AbstractInstanceEndpointUpdater<StatusInfo> {
 
 	private static final ParameterizedTypeReference<Map<String, Object>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {
 	};
 
-	private final InstanceRepository repository;
-
-	private final InstanceWebClient instanceWebClient;
-
-	private final ApiMediaTypeHandler apiMediaTypeHandler;
-
 	private Duration timeout = Duration.ofSeconds(10);
+
+	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
+			ApiMediaTypeHandler apiMediaTypeHandler) {
+		super(repository, instanceWebClient, apiMediaTypeHandler);
+	}
 
 	public StatusUpdater timeout(Duration timeout) {
 		this.timeout = timeout;
@@ -68,24 +64,47 @@ public class StatusUpdater {
 	}
 
 	public Mono<Void> updateStatus(InstanceId id) {
-		return this.repository.computeIfPresent(id, (key, instance) -> this.doUpdateStatus(instance)).then();
+		return update(id);
 	}
 
-	protected Mono<Instance> doUpdateStatus(Instance instance) {
-		if (!instance.isRegistered()) {
-			return Mono.empty();
-		}
+	@Override
+	protected boolean shouldUpdate(Instance instance) {
+		return instance.isRegistered();
+	}
 
+	@Override
+	protected void logUpdate(Instance instance) {
 		log.debug("Update status for {}", instance);
-		return this.instanceWebClient.instance(instance)
-			.get()
-			.uri(Endpoint.HEALTH)
-			.exchangeToMono(this::convertStatusInfo)
-			.log(log.getName(), Level.FINEST)
-			.timeout(getTimeoutWithMargin())
-			.doOnError((ex) -> logError(instance, ex))
-			.onErrorResume(this::handleError)
-			.map(instance::withStatusInfo);
+	}
+
+	@Override
+	protected String getEndpoint() {
+		return Endpoint.HEALTH;
+	}
+
+	@Override
+	protected Mono<StatusInfo> convertResponse(Instance instance, ClientResponse response) {
+		return convertStatusInfo(response);
+	}
+
+	@Override
+	protected Mono<StatusInfo> applyRequestOptions(Mono<StatusInfo> response) {
+		return response.timeout(getTimeoutWithMargin());
+	}
+
+	@Override
+	protected Mono<StatusInfo> handleError(Instance instance, Throwable ex) {
+		return handleError(ex);
+	}
+
+	@Override
+	protected Instance applyUpdate(Instance instance, StatusInfo statusInfo) {
+		return instance.withStatusInfo(statusInfo);
+	}
+
+	@Override
+	protected String getLoggerName() {
+		return log.getName();
 	}
 
 	/*
@@ -100,7 +119,7 @@ public class StatusUpdater {
 		boolean hasCompatibleContentType = response.headers()
 			.contentType()
 			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON)
-					|| this.apiMediaTypeHandler.isApiMediaType(mt))
+					|| getApiMediaTypeHandler().isApiMediaType(mt))
 			.isPresent();
 
 		StatusInfo statusInfoFromStatus = this.getStatusInfoFromStatus(response.statusCode(), emptyMap());
@@ -139,6 +158,7 @@ public class StatusUpdater {
 		return Mono.just(StatusInfo.ofOffline(details));
 	}
 
+	@Override
 	protected void logError(Instance instance, Throwable ex) {
 		if (instance.getStatusInfo().isOffline()) {
 			log.debug("Couldn't retrieve status for {}", instance, ex);


### PR DESCRIPTION
## Summary

This PR closes #30 by refactoring StatusUpdater and InfoUpdater toward the Template Method pattern.

Previously, StatusUpdater and InfoUpdater each owned a similar endpoint update workflow: repository lookup, eligibility check, endpoint request, response conversion, error handling, and applying the updated value back to the instance. The repeated workflow made future updater changes more error-prone because shared behavior could drift between the two classes.

After this refactor, AbstractInstanceEndpointUpdater owns the shared update skeleton. StatusUpdater and InfoUpdater now provide only the endpoint-specific steps such as eligibility, endpoint selection, response conversion, error handling, and applying the updated value.

## Design Pattern

Pattern used: Template Method

- AbstractInstanceEndpointUpdater defines the shared endpoint update workflow.
- StatusUpdater supplies status-specific behavior for the health endpoint.
- InfoUpdater supplies info-specific behavior for the info endpoint.
- The duplicated workflow is centralized without changing the public updater methods.

## Behavior Change

No user-visible behavior was intentionally changed.

## Verification

Ran:

.\mvnw.cmd -pl spring-boot-admin-server "-Dtest=StatusUpdaterTest,InfoUpdaterTest" test

Result:

Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

Also ran:

.\mvnw.cmd -pl spring-boot-admin-server -DskipTests compile

Result:

BUILD SUCCESS

Closes #30